### PR TITLE
Fix PHP7.1 compatibility problem

### DIFF
--- a/src/Ncmb/ApiClient.php
+++ b/src/Ncmb/ApiClient.php
@@ -292,7 +292,7 @@ class ApiClient
 
         uksort($params, 'strnatcmp');
 
-        $encoded_params = '';
+        $encoded_params = [];
         foreach ($params as $k => $v) {
             if ($k === 'X-NCMB-Timestamp') {
                 $encoded_params[] = $k . '=' . $v;


### PR DESCRIPTION
Hi,

This code may cause following error:

```
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php:300
Stack trace:
#0 /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php(241): Ncmb\ApiClient->sign('POST', 'https://mb.api....', Array, '2018-01-31T04:3...')
#1 /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php(209): Ncmb\ApiClient->createDefaultHeaders('POST', 'https://mb.api....', Array, NULL)
#2 /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php(138): Ncmb\ApiClient->send('POST', 'push', Array, NULL)
#3 /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php(68): Ncmb\ApiClient::request('POST', 'push', Array, NULL, NULL, Object(Ncmb\ApiClient), false)
#4 /vendor/ncmbmania/php-ncmb/src/Ncmb/Push.php(45): Ncmb\ApiClient::post('push', A in /vendor/ncmbmania/php-ncmb/src/Ncmb/ApiClient.php on line 300
```

Since PHP7.1, applying the empty index operator to a string (e.g. $str[] = $x) throws a fatal error. I found this on PHP7.1.7.

[PHP: Backward incompatible changes \- Manual](http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.empty-string-index-operator)