### PR TITLE
Patch rename object

### DIFF
--- a/src/Ncmb/Encoder.php
+++ b/src/Ncmb/Encoder.php
@@ -27,7 +27,7 @@ class Encoder
             return $value;
         }
 
-        if ($value instanceof \Ncmb\Object) {
+        if ($value instanceof \Ncmb\NCMBObject) {
             return $value->toPointer();
         }
 

--- a/src/Ncmb/Installation.php
+++ b/src/Ncmb/Installation.php
@@ -26,4 +26,22 @@ class Installation extends Object
         return 'installations';
     }
 
+	/**
+	 * Installation Update
+	 *
+	 * @return $this
+	 */
+	public function update() {
+		$path    = $this->getApiPath() . '/' . self::getObjectId();
+		$options = [
+			// FIXME: support operations
+			'json' => $this->getSaveData(),
+		];
+
+		$data = ApiClient::put( $path, $options );
+		$this->mergeAfterFetch( $data, false );
+
+		return $this;
+	}
+
 }

--- a/src/Ncmb/Installation.php
+++ b/src/Ncmb/Installation.php
@@ -5,7 +5,7 @@ namespace Ncmb;
 /**
  * Installation class
  */
-class Installation extends Object
+class Installation extends NCMBObject
 {
     /**
      * Constructor

--- a/src/Ncmb/NCMBObject.php
+++ b/src/Ncmb/NCMBObject.php
@@ -8,7 +8,7 @@ use Ncmb\Relation;
 /**
  * Object class
  */
-class Object implements Encodable
+class NCMBObject implements Encodable
 {
     const RESERVED_KEYS = [
         'objectId',
@@ -573,7 +573,7 @@ class Object implements Encodable
                 return new \DateTime($data['iso']);
                 break;
             case 'Pointer':
-                return Object::create($data['className'], $data['objectId']);
+                return NCMBObject::create($data['className'], $data['objectId']);
                 break;
             case 'Relation':
                 throw new Exception('Relation not allowed here');

--- a/src/Ncmb/Operation/AddUnique.php
+++ b/src/Ncmb/Operation/AddUnique.php
@@ -89,7 +89,7 @@ class AddUnique implements FieldOperation
     private function isNcmbObjectInArray($target, $oldValue)
     {
         foreach ($oldValue as $object) {
-            if ($object instanceof \Ncmb\Object &&
+            if ($object instanceof \Ncmb\NCMBObject &&
                 $object->getObjectId() != null) {
                 if ($object->getObjectId() == $target->getObjectId()) {
                     return true;

--- a/src/Ncmb/Operation/Remove.php
+++ b/src/Ncmb/Operation/Remove.php
@@ -71,8 +71,8 @@ class Remove implements FieldOperation
         $newValue = [];
         foreach ($oldValue as $oldObject) {
             foreach ($this->objects as $newObject) {
-                if ($oldObject instanceof \Ncmb\Object) {
-                    if ($newObject instanceof \Ncmb\Object
+                if ($oldNCMBObject instanceof \Ncmb\NCMBObject) {
+                    if ($newNCMBObject instanceof \Ncmb\NCMBObject
                         && !$oldObject->isDirty()
                         && $oldObject->getObjectId() == $newObject->getObjectId()
                     ) {

--- a/src/Ncmb/Push.php
+++ b/src/Ncmb/Push.php
@@ -4,7 +4,7 @@ namespace Ncmb;
 /**
  * Push  - Handles sending push notifications with NCMB.
  */
-class Push extends Object
+class Push extends NCMBObject
 {
     const VALID_OPTION_KEY = [
         'deliveryTime',

--- a/src/Ncmb/Query.php
+++ b/src/Ncmb/Query.php
@@ -159,7 +159,7 @@ class Query
                 $mergeRequired = false;
                 break;
             default:
-                $obj = Object::create($className, $objectId);
+                $obj = NCMBObject::create($className, $objectId);
         }
         if ($mergeRequired) {
             $obj->mergeAfterFetch($row);

--- a/src/Ncmb/Role.php
+++ b/src/Ncmb/Role.php
@@ -5,7 +5,7 @@ namespace Ncmb;
 /**
  * Role - Representation of an access Role.
  */
-class Role extends Object
+class Role extends NCMBObject
 {
     const NCMB_CLASS_NAME = 'role';
     const API_PATH = 'roles';

--- a/src/Ncmb/User.php
+++ b/src/Ncmb/User.php
@@ -5,7 +5,7 @@ namespace Ncmb;
 /**
  * User - Representation of a user object stored on NCMB
  */
-class User extends Object
+class User extends NCMBObject
 {
     const NCMB_CLASS_NAME = 'user';
     const API_PATH = 'users';


### PR DESCRIPTION
PHP7.2ではObjectというクラス名が使用できないようで、エラーが出ていたのでリネームしました。
以前のプルリクの修正も一緒に入っていますのでよろしくおねがいします。